### PR TITLE
Update trades API to match new schema

### DIFF
--- a/src/app/api/buckets/[id]/trades/route.js
+++ b/src/app/api/buckets/[id]/trades/route.js
@@ -3,15 +3,17 @@ import { verifyUserFromCookie } from "@/lib/authMiddleware";
 import { supabaseAdmin } from "@/lib/supabaseAdmin";
 
 export async function GET(request, { params }) {
-  const { id: bucketId } = await params;
+  const { id: bucketId } = params;
   const user = await verifyUserFromCookie(request);
 
   const { data, error } = await supabaseAdmin
     .from("trades")
-    .select("id, stock, type, quantity, price, date, notes, created_at")
+    .select(
+      "id, stock, notes, created_at, status, profit_loss, market, target, stop_loss, trade_entries(id, action, ts, quantity, price, fee, notes)"
+    )
     .eq("bucket_id", bucketId)
     .eq("user_id", user.id)
-    .order("date", { ascending: false });
+    .order("created_at", { ascending: false });
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
@@ -20,28 +22,40 @@ export async function GET(request, { params }) {
 }
 
 export async function POST(request, { params }) {
-  const { id: bucketId } = await params;
+  const { id: bucketId } = params;
   const user = await verifyUserFromCookie(request);
-  const { stock, type, quantity, price, date, notes } = await request.json();
+  const { stock, notes, market, target, stop_loss, entries } = await request.json();
 
-  const { data, error } = await supabaseAdmin
+  const { data: trade, error } = await supabaseAdmin
     .from("trades")
     .insert([
       {
         user_id: user.id,
         bucket_id: bucketId,
         stock,
-        type,
-        quantity,
-        price,
-        date,
         notes,
+        market,
+        target,
+        stop_loss,
       },
     ])
+    .select()
     .single();
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
-  return NextResponse.json(data, { status: 201 });
+
+  if (entries && Array.isArray(entries) && entries.length > 0) {
+    const entriesData = entries.map((e) => ({ ...e, trade_id: trade.id }));
+    const { error: entriesError } = await supabaseAdmin
+      .from("trade_entries")
+      .insert(entriesData);
+
+    if (entriesError) {
+      return NextResponse.json({ error: entriesError.message }, { status: 500 });
+    }
+  }
+
+  return NextResponse.json(trade, { status: 201 });
 }


### PR DESCRIPTION
## Summary
- update the trades GET and POST handlers to work with the new database schema

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854e8b2adc883268a93a6ec3977b3e2