### PR TITLE
Fix bucket details fetch

### DIFF
--- a/src/app/api/buckets/[id]/route.js
+++ b/src/app/api/buckets/[id]/route.js
@@ -19,7 +19,10 @@ export async function GET(request, { params }) {
 
     const { data: trades, error: tradesErr } = await supabaseAdmin
       .from("trades")
-      .select("id, market, target, stop_loss, notes, created_at, bucket_id")
+      .select(
+        `id, stock, notes, created_at, status, profit_loss, market, target, stop_loss, bucket_id,
+        trade_entries(id, trade_id, action, date_time, quantity, price, notes)`
+      )
       .eq("bucket_id", bucketId)
       .eq("user_id", user.id)
       .order("created_at", { ascending: true });

--- a/src/app/api/buckets/[id]/trades/route.js
+++ b/src/app/api/buckets/[id]/trades/route.js
@@ -38,9 +38,6 @@ export async function POST(request, { params }) {
         market,
         target,
         stop_loss,
-        market,
-        target,
-        stop_loss,
       },
     ])
     .select()


### PR DESCRIPTION
## Summary
- ensure bucket details endpoint also returns trade entry data
- remove duplicate trade field insertions

## Testing
- `npm ci`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685ba59dfbfc8326a7f25fb57875985e