### PR TITLE
Add bucket size with deposit/withdraw

### DIFF
--- a/src/app/api/buckets/[id]/route.js
+++ b/src/app/api/buckets/[id]/route.js
@@ -40,11 +40,11 @@ export async function POST(request, { params }) {
   try {
     const user = await verifyUserFromCookie(request);
     const bucketId = params.id;
-    const { budget } = await request.json();
+    const { bucket_size } = await request.json();
 
     const { data, error } = await supabaseAdmin
       .from("buckets")
-      .update({ budget })
+      .update({ bucket_size })
       .eq("id", bucketId)
       .eq("user_id", user.id)
       .select()

--- a/src/app/api/buckets/route.js
+++ b/src/app/api/buckets/route.js
@@ -28,10 +28,10 @@ export async function POST(request) {
   try {
     const user = await verifyUserFromCookie(request);
 
-    const { name } = await request.json();
+    const { name, bucket_size } = await request.json();
     const { data, error } = await supabaseAdmin
       .from("buckets")
-      .insert([{ user_id: user.id, name }])
+      .insert([{ user_id: user.id, name, bucket_size }])
       .select()
       .single();
 

--- a/src/app/buckets/[id]/page.js
+++ b/src/app/buckets/[id]/page.js
@@ -20,7 +20,8 @@ import AddTradeForm from "@/components/trades/AddTradeForm";
 export default function BucketDetailsPage() {
   const { id } = useParams();
   const router = useRouter();
-  const [budget, setBudget] = useState(0);
+  const [bucketSize, setBucketSize] = useState(0);
+  const [amount, setAmount] = useState(0);
   const [available, setAvailable] = useState(0);
   const [locked, setLocked] = useState(0);
   const [wins, setWins] = useState(0);
@@ -44,9 +45,9 @@ export default function BucketDetailsPage() {
       const data = res.data;
       setTestData(data);
       setBucketName(data.name);
-      setBudget(data.budget || 0);
+      setBucketSize(data.bucket_size || 0);
       setTrades(data.trades || []);
-      setAvailable(data.budget || 0);
+      setAvailable(data.bucket_size || 0);
       setLocked(0);
       setOpenTrades((data.trades || []).length);
       setClosedTrades(0);
@@ -96,13 +97,13 @@ export default function BucketDetailsPage() {
             <h1 className="text-3xl font-bold">{bucketName}</h1>
           </div>
 
-          {/* Budget Setter */}
+          {/* Bucket Size Adjuster */}
           <div className="mt-6 flex items-center space-x-2">
             <Input
               type="number"
-              value={budget}
-              onChange={(e) => setBudget(Number(e.target.value))}
-              placeholder="Budget"
+              value={amount}
+              onChange={(e) => setAmount(Number(e.target.value))}
+              placeholder="Amount"
               className="w-32"
             />
             <Button
@@ -110,16 +111,35 @@ export default function BucketDetailsPage() {
                 try {
                   await axios.post(
                     `/api/buckets/${id}`,
-                    { budget },
+                    { bucket_size: bucketSize + amount },
                     { withCredentials: true }
                   );
+                  setAmount(0);
                   fetchBucket();
                 } catch (err) {
                   console.error(err);
                 }
               }}
             >
-              Set Budget
+              +
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={async () => {
+                try {
+                  await axios.post(
+                    `/api/buckets/${id}`,
+                    { bucket_size: bucketSize - amount },
+                    { withCredentials: true }
+                  );
+                  setAmount(0);
+                  fetchBucket();
+                } catch (err) {
+                  console.error(err);
+                }
+              }}
+            >
+              -
             </Button>
           </div>
 
@@ -149,8 +169,8 @@ export default function BucketDetailsPage() {
           <div className="flex flex-wrap justify-center gap-3">
             {[
               {
-                label: "Budget",
-                value: `$${budget.toLocaleString()}`,
+                label: "Bucket Size",
+                value: `$${bucketSize.toLocaleString()}`,
                 positive: null,
               },
               {

--- a/src/app/buckets/page.js
+++ b/src/app/buckets/page.js
@@ -35,9 +35,9 @@ export default function Buckets() {
     fetchBuckets();
   }, [fetchBuckets]);
 
-  const handleCreate = (name) => {
+  const handleCreate = (name, bucketSize) => {
     console.log(buckets);
-    createBucket(name);
+    createBucket(name, bucketSize);
     setShowCreateModal(false);
   };
 

--- a/src/components/buckets/CreateBucketModal.jsx
+++ b/src/components/buckets/CreateBucketModal.jsx
@@ -14,6 +14,7 @@ import { Label } from "@/components/ui/label";
 
 export default function CreateBucketModal({ onClose, onCreate }) {
   const [name, setName] = useState("");
+  const [bucketSize, setBucketSize] = useState(0);
 
   return (
     <Dialog open onOpenChange={(open) => !open && onClose()}>
@@ -34,12 +35,22 @@ export default function CreateBucketModal({ onClose, onCreate }) {
               placeholder="My Strategy"
             />
           </div>
+          <div className="grid gap-2">
+            <Label htmlFor="bucket-size">Bucket Size</Label>
+            <Input
+              id="bucket-size"
+              type="number"
+              value={bucketSize}
+              onChange={(e) => setBucketSize(Number(e.target.value))}
+              placeholder="1000"
+            />
+          </div>
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={onClose}>
             Cancel
           </Button>
-          <Button onClick={() => onCreate(name)}>Create</Button>
+          <Button onClick={() => onCreate(name, bucketSize)}>Create</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/store/useBucketStore.js
+++ b/src/store/useBucketStore.js
@@ -11,14 +11,19 @@ export const useBucketStore = create((set, get) => ({
       console.error(e);
     }
   },
-  createBucket: async (name) => {
+  createBucket: async (name, bucketSize) => {
     const tempId = crypto.randomUUID();
-    set({ buckets: [...get().buckets, { id: tempId, name, trade_count: 0 }] });
+    set({
+      buckets: [
+        ...get().buckets,
+        { id: tempId, name, bucket_size: bucketSize, trade_count: 0 },
+      ],
+    });
     try {
       const res = await axios.post(
         "/api/buckets",
-        { name },
-        { withCredentaisl: true }
+        { name, bucket_size: bucketSize },
+        { withCredentials: true }
       );
       set({
         buckets: get().buckets.map((b) => (b.id === tempId ? res.data : b)),


### PR DESCRIPTION
## Summary
- add Bucket Size field when creating a bucket
- allow specifying bucket size in store and API
- add deposit/withdraw controls on bucket detail page
- update API routes to handle `bucket_size`

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6865f742f36083268323f78f9440b26b