### PR TITLE
Add tabs for bucket tables

### DIFF
--- a/src/app/api/buckets/[id]/route.js
+++ b/src/app/api/buckets/[id]/route.js
@@ -31,7 +31,7 @@ export async function GET(request, { params }) {
 
     const { data: transactions, error: txErr } = await supabaseAdmin
       .from("bucket_transactions")
-      .select("id, amount, created_at")
+      .select("id, amount, description, qty, price, created_at")
       .eq("bucket_id", bucketId)
       .eq("user_id", user.id)
       .order("created_at", { ascending: true });
@@ -76,7 +76,12 @@ export async function POST(request, { params }) {
 
     if (delta !== 0) {
       await supabaseAdmin.from("bucket_transactions").insert([
-        { bucket_id: bucketId, user_id: user.id, amount: delta },
+        {
+          bucket_id: bucketId,
+          user_id: user.id,
+          amount: delta,
+          description: delta > 0 ? "Deposit" : "Withdraw",
+        },
       ]);
     }
 

--- a/src/app/api/buckets/[id]/sell/route.js
+++ b/src/app/api/buckets/[id]/sell/route.js
@@ -15,7 +15,7 @@ export async function POST(request, { params }) {
     const { trade_id, qty } = alloc;
     const { data: trade, error } = await supabaseAdmin
       .from("trades")
-      .select("quantity, price")
+      .select("quantity, price, symbol")
       .eq("id", trade_id)
       .eq("bucket_id", bucketId)
       .eq("user_id", user.id)
@@ -37,6 +37,17 @@ export async function POST(request, { params }) {
       .eq("id", trade_id)
       .eq("bucket_id", bucketId)
       .eq("user_id", user.id);
+
+    await supabaseAdmin.from("bucket_transactions").insert([
+      {
+        bucket_id: bucketId,
+        user_id: user.id,
+        amount: Number(price) * Number(qty),
+        description: `${trade.symbol} - SELL`,
+        qty,
+        price,
+      },
+    ]);
   }
 
   return NextResponse.json({ message: "Trades updated" });

--- a/src/app/api/buckets/[id]/trades/route.js
+++ b/src/app/api/buckets/[id]/trades/route.js
@@ -68,5 +68,17 @@ export async function POST(request, { params }) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
+  const tradeAmount = -Number(price) * Number(quantity);
+  await supabaseAdmin.from("bucket_transactions").insert([
+    {
+      bucket_id: bucketId,
+      user_id: user.id,
+      amount: tradeAmount,
+      description: `${symbol} - BUY`,
+      qty: quantity,
+      price,
+    },
+  ]);
+
   return NextResponse.json(trade, { status: 201 });
 }

--- a/src/app/api/buckets/[id]/transactions/route.js
+++ b/src/app/api/buckets/[id]/transactions/route.js
@@ -8,7 +8,7 @@ export async function GET(request, { params }) {
     const bucketId = params.id;
     const { data, error } = await supabaseAdmin
       .from("bucket_transactions")
-      .select("id, amount, created_at")
+      .select("id, amount, description, qty, price, created_at")
       .eq("bucket_id", bucketId)
       .eq("user_id", user.id)
       .order("created_at", { ascending: true });
@@ -25,10 +25,20 @@ export async function POST(request, { params }) {
   try {
     const user = await verifyUserFromCookie(request);
     const bucketId = params.id;
-    const { amount } = await request.json();
+    const { amount, description = null, qty = null, price = null } =
+      await request.json();
     const { data, error } = await supabaseAdmin
       .from("bucket_transactions")
-      .insert([{ bucket_id: bucketId, user_id: user.id, amount }])
+      .insert([
+        {
+          bucket_id: bucketId,
+          user_id: user.id,
+          amount,
+          description,
+          qty,
+          price,
+        },
+      ])
       .select()
       .single();
     if (error) {

--- a/src/app/api/buckets/route.js
+++ b/src/app/api/buckets/route.js
@@ -42,7 +42,12 @@ export async function POST(request) {
 
     if (bucket_size) {
       await supabaseAdmin.from("bucket_transactions").insert([
-        { bucket_id: data.id, user_id: user.id, amount: bucket_size },
+        {
+          bucket_id: data.id,
+          user_id: user.id,
+          amount: bucket_size,
+          description: "Initial Deposit",
+        },
       ]);
     }
 

--- a/src/app/buckets/[id]/page.js
+++ b/src/app/buckets/[id]/page.js
@@ -271,6 +271,8 @@ export default function BucketDetailsPage() {
                   <TableRow>
                     <TableHead>Date</TableHead>
                     <TableHead>Description</TableHead>
+                    <TableHead>Qty</TableHead>
+                    <TableHead>Price ($)</TableHead>
                     <TableHead>Change ($)</TableHead>
                     <TableHead>Balance ($)</TableHead>
                   </TableRow>
@@ -284,11 +286,19 @@ export default function BucketDetailsPage() {
                           : "-"}
                       </TableCell>
                       <TableCell>
-                        {idx === 0
+                        {tx.description
+                          ? tx.description
+                          : idx === 0
                           ? "Initial Bucket Size"
                           : tx.amount > 0
                           ? "Deposit"
                           : "Withdraw"}
+                      </TableCell>
+                      <TableCell>{tx.qty ?? ""}</TableCell>
+                      <TableCell>
+                        {tx.price !== null && tx.price !== undefined
+                          ? Number(tx.price).toFixed(2)
+                          : ""}
                       </TableCell>
                       <TableCell
                         className={

--- a/src/app/buckets/[id]/page.js
+++ b/src/app/buckets/[id]/page.js
@@ -24,6 +24,12 @@ import {
   TableHead,
   TableCell,
 } from "@/components/ui/table";
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from "@/components/ui/tabs";
 import AddTradeForm from "@/components/trades/AddTradeForm";
 import SellTradeForm from "@/components/trades/SellTradeForm";
 
@@ -253,113 +259,116 @@ export default function BucketDetailsPage() {
             ))}
           </div>
 
-          {/* Bucket Activity Table */}
-          <div className="overflow-auto">
-            <h2 className="font-semibold mb-2">Bucket Activity</h2>
-            <Table className="min-w-full">
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Date</TableHead>
-                  <TableHead>Description</TableHead>
-                  <TableHead>Change ($)</TableHead>
-                  <TableHead>Balance ($)</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {transactionRows.map((tx, idx) => (
-                  <TableRow key={tx.id ?? idx}>
-                    <TableCell>
-                      {tx.created_at
-                        ? new Date(tx.created_at).toLocaleDateString("en-GB")
-                        : "-"}
-                    </TableCell>
-                    <TableCell>
-                      {idx === 0
-                        ? "Initial Bucket Size"
-                        : tx.amount > 0
-                        ? "Deposit"
-                        : "Withdraw"}
-                    </TableCell>
-                    <TableCell
-                      className={
-                        tx.amount >= 0 ? "text-green-600" : "text-red-600"
-                      }
-                    >
-                      {tx.amount >= 0
-                        ? `+$${Number(tx.amount).toLocaleString()}`
-                        : `-$${Math.abs(Number(tx.amount)).toLocaleString()}`}
-                    </TableCell>
-                    <TableCell>{`$${Number(tx.balance).toLocaleString()}`}</TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
+          <Tabs defaultValue="activity" className="w-full">
+            <TabsList className="mb-2">
+              <TabsTrigger value="activity">Bucket Activity</TabsTrigger>
+              <TabsTrigger value="trades">Trades</TabsTrigger>
+            </TabsList>
 
-          {/* Trades Table */}
-          <div className="overflow-auto min-h-[19rem]">
-            <Table className="min-w-full">
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Date</TableHead>
-                  <TableHead>Symbol</TableHead>
-                  <TableHead>Status</TableHead>
-                  <TableHead>Qty</TableHead>
-                  <TableHead>Entry ($)</TableHead>
-                  <TableHead>Exit ($)</TableHead>
-                  {/* Removed Ent Total and Ext Total columns */}
-                  <TableHead>Hold</TableHead>
-                  <TableHead>Return ($)</TableHead>
-                  <TableHead>Return %</TableHead>
-                  <TableHead>Actions</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {trades.map((t) => (
-                  <TableRow
-                    key={t.id}
-                    className="cursor-pointer"
-                    onClick={() => {
-                      setEditingTrade(t);
-                      setShowTradeForm(true);
-                    }}
-                  >
-                    <TableCell>
-                      {t?.created_at
-                        ? new Date(t.created_at).toLocaleDateString("en-GB")
-                        : "-"}
-                    </TableCell>
-                    <TableCell>{t.symbol || ""}</TableCell>
-                    <TableCell>{t.status || ""}</TableCell>
-                    <TableCell>{t.quantity}</TableCell>
-                    <TableCell>{Number(t.price).toFixed(2)}</TableCell>
-                    <TableCell>{t.exit_price ?? ""}</TableCell>
-                    <TableCell>{t.holdDuration || "2 Days"}</TableCell>
-                    <TableCell>{t.return_amount ?? ""}</TableCell>
-                    <TableCell>
-                      {t.return_percent ? `${t.return_percent}%` : ""}
-                    </TableCell>
-                    <TableCell className="space-x-1">
-                      <Button
-                        variant="destructive"
-                        size="sm"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        Sell
-                      </Button>
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        <Trash className="size-4" />
-                      </Button>
-                    </TableCell>
+            <TabsContent value="activity" className="overflow-auto">
+              <Table className="min-w-full">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Date</TableHead>
+                    <TableHead>Description</TableHead>
+                    <TableHead>Change ($)</TableHead>
+                    <TableHead>Balance ($)</TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
+                </TableHeader>
+                <TableBody>
+                  {transactionRows.map((tx, idx) => (
+                    <TableRow key={tx.id ?? idx}>
+                      <TableCell>
+                        {tx.created_at
+                          ? new Date(tx.created_at).toLocaleDateString("en-GB")
+                          : "-"}
+                      </TableCell>
+                      <TableCell>
+                        {idx === 0
+                          ? "Initial Bucket Size"
+                          : tx.amount > 0
+                          ? "Deposit"
+                          : "Withdraw"}
+                      </TableCell>
+                      <TableCell
+                        className={
+                          tx.amount >= 0 ? "text-green-600" : "text-red-600"
+                        }
+                      >
+                        {tx.amount >= 0
+                          ? `+$${Number(tx.amount).toLocaleString()}`
+                          : `-$${Math.abs(Number(tx.amount)).toLocaleString()}`}
+                      </TableCell>
+                      <TableCell>{`$${Number(tx.balance).toLocaleString()}`}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TabsContent>
+
+            <TabsContent value="trades" className="overflow-auto min-h-[19rem]">
+              <Table className="min-w-full">
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Date</TableHead>
+                    <TableHead>Symbol</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Qty</TableHead>
+                    <TableHead>Entry ($)</TableHead>
+                    <TableHead>Exit ($)</TableHead>
+                    <TableHead>Hold</TableHead>
+                    <TableHead>Return ($)</TableHead>
+                    <TableHead>Return %</TableHead>
+                    <TableHead>Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {trades.map((t) => (
+                    <TableRow
+                      key={t.id}
+                      className="cursor-pointer"
+                      onClick={() => {
+                        setEditingTrade(t);
+                        setShowTradeForm(true);
+                      }}
+                    >
+                      <TableCell>
+                        {t?.created_at
+                          ? new Date(t.created_at).toLocaleDateString("en-GB")
+                          : "-"}
+                      </TableCell>
+                      <TableCell>{t.symbol || ""}</TableCell>
+                      <TableCell>{t.status || ""}</TableCell>
+                      <TableCell>{t.quantity}</TableCell>
+                      <TableCell>{Number(t.price).toFixed(2)}</TableCell>
+                      <TableCell>{t.exit_price ?? ""}</TableCell>
+                      <TableCell>{t.holdDuration || "2 Days"}</TableCell>
+                      <TableCell>{t.return_amount ?? ""}</TableCell>
+                      <TableCell>
+                        {t.return_percent ? `${t.return_percent}%` : ""}
+                      </TableCell>
+                      <TableCell className="space-x-1">
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          Sell
+                        </Button>
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <Trash className="size-4" />
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TabsContent>
+          </Tabs>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- add Tabs to display bucket activity vs trades

## Testing
- `npx next lint` *(fails: needs 'next' package installation)*

------
https://chatgpt.com/codex/tasks/task_e_686e24109a9c8326a2e08150795f71dd