### PR TITLE
Add global trades search page

### DIFF
--- a/src/app/api/trades/route.js
+++ b/src/app/api/trades/route.js
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { verifyUserFromCookie } from "@/lib/authMiddleware";
+import { supabaseAdmin } from "@/lib/supabaseAdmin";
+
+export async function GET(request) {
+  try {
+    const user = await verifyUserFromCookie(request);
+    const { searchParams } = new URL(request.url);
+    const symbol = searchParams.get("symbol");
+    const status = searchParams.get("status");
+    const bucketId = searchParams.get("bucket_id");
+
+    let query = supabaseAdmin
+      .from("trades")
+      .select(
+        "id, bucket_id, symbol, notes, created_at, status, market, target, stop_loss, quantity, price, exit_price, return_amount, return_percent, buckets(name)"
+      )
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: false });
+
+    if (symbol) query = query.ilike("symbol", `%${symbol}%`);
+    if (status) query = query.eq("status", status);
+    if (bucketId) query = query.eq("bucket_id", bucketId);
+
+    const { data, error } = await query;
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 401 });
+  }
+}

--- a/src/app/trades/page.js
+++ b/src/app/trades/page.js
@@ -75,12 +75,15 @@ export default function TradesPage() {
           </Select>
         </div>
         <div>
-          <Select value={bucketId} onValueChange={setBucketId}>
+          <Select
+            value={bucketId || undefined}
+            onValueChange={(v) => setBucketId(v === "all" ? "" : v)}
+          >
             <SelectTrigger className="w-40">
               <SelectValue placeholder="Bucket" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="">All Buckets</SelectItem>
+              <SelectItem value="all">All Buckets</SelectItem>
               {buckets.map((b) => (
                 <SelectItem key={b.id} value={b.id}>
                   {b.name}

--- a/src/app/trades/page.js
+++ b/src/app/trades/page.js
@@ -1,56 +1,50 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import axios from "axios";
-import Link from "next/link";
-import { useStore } from "../../store";
+import { useBucketStore } from "@/store/useBucketStore";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
 
-export default function Trades() {
-  const token = useStore((state) => state.token);
+export default function TradesPage() {
+  const buckets = useBucketStore((s) => s.buckets);
+  const fetchBuckets = useBucketStore((s) => s.fetchBuckets);
+
   const [trades, setTrades] = useState([]);
-  const [form, setForm] = useState({
-    bucket_id: "",
-    stock: "",
-    type: "BUY",
-    quantity: "",
-    price: "",
-    date: "",
-    notes: "",
-  });
-
-  const fetchTrades = async () => {
-    if (token) {
-      try {
-        const res = await axios.get("/api/trades", {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-        setTrades(res.data);
-      } catch (err) {
-        console.error(err);
-      }
-    }
-  };
+  const [symbol, setSymbol] = useState("");
+  const [status, setStatus] = useState("");
+  const [bucketId, setBucketId] = useState("");
 
   useEffect(() => {
+    fetchBuckets();
     fetchTrades();
-  }, [token]);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
+  const fetchTrades = async () => {
+    const params = new URLSearchParams();
+    if (symbol) params.set("symbol", symbol);
+    if (status) params.set("status", status);
+    if (bucketId) params.set("bucket_id", bucketId);
     try {
-      await axios.post("/api/trades", form, {
-        headers: { Authorization: `Bearer ${token}` },
+      const res = await axios.get(`/api/trades?${params.toString()}`, {
+        withCredentials: true,
       });
-      setForm({
-        bucket_id: "",
-        stock: "",
-        type: "BUY",
-        quantity: "",
-        price: "",
-        date: "",
-        notes: "",
-      });
-      fetchTrades();
+      setTrades(res.data || []);
     } catch (err) {
       console.error(err);
     }
@@ -58,118 +52,105 @@ export default function Trades() {
 
   return (
     <div className="container mx-auto p-4">
-      <nav className="mb-4">
-        <Link href="/">Dashboard</Link> | <Link href="/trades">Trades</Link> |{" "}
-        <Link href="/buckets">Buckets</Link> | <Link href="/chart">Charts</Link>
-      </nav>
       <h1 className="text-3xl mb-4">Trades</h1>
-      <form
-        onSubmit={handleSubmit}
-        className="bg-white p-4 rounded shadow-md mb-6"
-      >
-        <div className="mb-2">
-          <input
-            type="text"
-            placeholder="Bucket ID"
-            value={form.bucket_id}
-            onChange={(e) => setForm({ ...form, bucket_id: e.target.value })}
-            className="border p-2 w-full"
-            required
+
+      <div className="flex flex-wrap gap-2 mb-6 items-end">
+        <div>
+          <Input
+            placeholder="Symbol"
+            value={symbol}
+            onChange={(e) => setSymbol(e.target.value)}
+            className="w-32"
           />
         </div>
-        <div className="mb-2">
-          <input
-            type="text"
-            placeholder="Stock Symbol"
-            value={form.stock}
-            onChange={(e) => setForm({ ...form, stock: e.target.value })}
-            className="border p-2 w-full"
-            required
-          />
+        <div>
+          <Select value={status} onValueChange={setStatus}>
+            <SelectTrigger className="w-32">
+              <SelectValue placeholder="Status" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="OPEN">Open</SelectItem>
+              <SelectItem value="CLOSED">Closed</SelectItem>
+            </SelectContent>
+          </Select>
         </div>
-        <div className="mb-2">
-          <select
-            value={form.type}
-            onChange={(e) => setForm({ ...form, type: e.target.value })}
-            className="border p-2 w-full"
-          >
-            <option value="BUY">BUY</option>
-            <option value="SELL">SELL</option>
-          </select>
+        <div>
+          <Select value={bucketId} onValueChange={setBucketId}>
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="Bucket" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="">All Buckets</SelectItem>
+              {buckets.map((b) => (
+                <SelectItem key={b.id} value={b.id}>
+                  {b.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
-        <div className="mb-2">
-          <input
-            type="number"
-            placeholder="Quantity"
-            value={form.quantity}
-            onChange={(e) => setForm({ ...form, quantity: e.target.value })}
-            className="border p-2 w-full"
-            required
-          />
-        </div>
-        <div className="mb-2">
-          <input
-            type="number"
-            step="0.01"
-            placeholder="Price"
-            value={form.price}
-            onChange={(e) => setForm({ ...form, price: e.target.value })}
-            className="border p-2 w-full"
-            required
-          />
-        </div>
-        <div className="mb-2">
-          <input
-            type="date"
-            placeholder="Date"
-            value={form.date}
-            onChange={(e) => setForm({ ...form, date: e.target.value })}
-            className="border p-2 w-full"
-            required
-          />
-        </div>
-        <div className="mb-2">
-          <textarea
-            placeholder="Notes"
-            value={form.notes}
-            onChange={(e) => setForm({ ...form, notes: e.target.value })}
-            className="border p-2 w-full"
-          ></textarea>
-        </div>
-        <button
-          type="submit"
-          className="bg-blue-500 text-white p-2 rounded w-full"
-        >
-          Add Trade
-        </button>
-      </form>
-      <h2 className="text-2xl mb-2">Trade History</h2>
-      <table className="min-w-full bg-white">
-        <thead>
-          <tr>
-            <th className="py-2">Bucket ID</th>
-            <th className="py-2">Stock</th>
-            <th className="py-2">Type</th>
-            <th className="py-2">Quantity</th>
-            <th className="py-2">Price</th>
-            <th className="py-2">Date</th>
-            <th className="py-2">Notes</th>
-          </tr>
-        </thead>
-        <tbody>
-          {trades.map((trade) => (
-            <tr key={trade.id} className="text-center border-t">
-              <td className="py-2">{trade.bucket_id}</td>
-              <td className="py-2">{trade.stock}</td>
-              <td className="py-2">{trade.type}</td>
-              <td className="py-2">{trade.quantity}</td>
-              <td className="py-2">{trade.price}</td>
-              <td className="py-2">{trade.date}</td>
-              <td className="py-2">{trade.notes}</td>
-            </tr>
+        <Button onClick={fetchTrades}>Search</Button>
+      </div>
+
+      <Table className="min-w-full">
+        <TableHeader>
+          <TableRow>
+            <TableHead>Date</TableHead>
+            <TableHead>Bucket</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Symbol</TableHead>
+            <TableHead>Qty</TableHead>
+            <TableHead>Entry ($)</TableHead>
+            <TableHead>Exit ($)</TableHead>
+            <TableHead>Return ($)</TableHead>
+            <TableHead>Return %</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {trades.map((t) => (
+            <TableRow key={t.id}>
+              <TableCell>
+                {t.created_at
+                  ? new Date(t.created_at).toLocaleDateString("en-GB")
+                  : "-"}
+              </TableCell>
+              <TableCell>
+                {t.buckets?.name ||
+                  buckets.find((b) => b.id === t.bucket_id)?.name || ""}
+              </TableCell>
+              <TableCell>
+                <span
+                  className={`px-3 py-1 rounded-full text-[11px] ${
+                    t.status === "OPEN"
+                      ? "bg-green-500 text-white"
+                      : "bg-red-500 text-white"
+                  }`}
+                >
+                  {t.status}
+                </span>
+              </TableCell>
+              <TableCell>{t.symbol}</TableCell>
+              <TableCell>{t.quantity}</TableCell>
+              <TableCell>{Number(t.price).toFixed(2)}</TableCell>
+              <TableCell>
+                {t.exit_price !== null && t.exit_price !== undefined
+                  ? Number(t.exit_price).toFixed(2)
+                  : ""}
+              </TableCell>
+              <TableCell>
+                {t.return_amount !== null && t.return_amount !== undefined
+                  ? Number(t.return_amount).toFixed(2)
+                  : ""}
+              </TableCell>
+              <TableCell>
+                {t.return_percent !== null && t.return_percent !== undefined
+                  ? `${Number(t.return_percent).toFixed(2)}%`
+                  : ""}
+              </TableCell>
+            </TableRow>
           ))}
-        </tbody>
-      </table>
+        </TableBody>
+      </Table>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create API route for retrieving trades across all buckets
- revamp trades page to show a searchable table using ShadCN components

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686f47a2f0348326bbb95ed82a786316