### PR TITLE
Fix cash checks for buckets

### DIFF
--- a/src/app/api/buckets/[id]/sell/route.js
+++ b/src/app/api/buckets/[id]/sell/route.js
@@ -11,6 +11,7 @@ export async function POST(request, { params }) {
     return NextResponse.json({ error: "No allocations" }, { status: 400 });
   }
 
+  let totalProfit = 0;
   for (const alloc of allocations) {
     const { trade_id, qty } = alloc;
     const { data: trade, error } = await supabaseAdmin
@@ -22,7 +23,9 @@ export async function POST(request, { params }) {
       .single();
     if (error || !trade) continue;
 
-    const remaining = Number(trade.quantity) - Number(qty);
+    const sellQty = Number(qty);
+    if (sellQty <= 0 || sellQty > Number(trade.quantity)) continue;
+    const remaining = Number(trade.quantity) - sellQty;
     const updates = { quantity: remaining };
     if (remaining <= 0) {
       updates.status = "CLOSED";
@@ -38,16 +41,36 @@ export async function POST(request, { params }) {
       .eq("bucket_id", bucketId)
       .eq("user_id", user.id);
 
+    const sellValue = Number(price) * sellQty;
+    const costValue = Number(trade.price) * sellQty;
+    totalProfit += sellValue - costValue;
+
     await supabaseAdmin.from("bucket_transactions").insert([
       {
         bucket_id: bucketId,
         user_id: user.id,
-        amount: Number(price) * Number(qty),
+        amount: sellValue,
         description: `${trade.symbol} - SELL`,
-        qty,
+        qty: sellQty,
         price,
       },
     ]);
+  }
+
+  if (totalProfit !== 0) {
+    const { data: bucket } = await supabaseAdmin
+      .from("buckets")
+      .select("bucket_size")
+      .eq("id", bucketId)
+      .eq("user_id", user.id)
+      .single();
+    if (bucket) {
+      await supabaseAdmin
+        .from("buckets")
+        .update({ bucket_size: Number(bucket.bucket_size) + totalProfit })
+        .eq("id", bucketId)
+        .eq("user_id", user.id);
+    }
   }
 
   return NextResponse.json({ message: "Trades updated" });

--- a/src/app/buckets/[id]/page.js
+++ b/src/app/buckets/[id]/page.js
@@ -51,6 +51,7 @@ export default function BucketDetailsPage() {
   const [showSellForm, setShowSellForm] = useState(false);
   const [editingTrade, setEditingTrade] = useState(null);
   const [testData, setTestData] = useState({});
+  const [adjustError, setAdjustError] = useState("");
 
   const transactionRows = useMemo(() => {
     let balance = 0;
@@ -135,6 +136,8 @@ export default function BucketDetailsPage() {
             <Button
               onClick={() => {
                 setAdjustType("deposit");
+                setAdjustAmount(0);
+                setAdjustError("");
                 setShowAdjustModal(true);
               }}
             >
@@ -144,6 +147,8 @@ export default function BucketDetailsPage() {
               variant="destructive"
               onClick={() => {
                 setAdjustType("withdraw");
+                setAdjustAmount(0);
+                setAdjustError("");
                 setShowAdjustModal(true);
               }}
             >
@@ -431,27 +436,38 @@ export default function BucketDetailsPage() {
                 {adjustType === "deposit" ? "Deposit Funds" : "Withdraw Funds"}
               </DialogTitle>
             </DialogHeader>
-            <div className="grid gap-2 mt-2">
-              <Label htmlFor="adjust-amount">$ Amount</Label>
-              <Input
-                id="adjust-amount"
-                type="number"
-                step="0.01"
-                inputMode="decimal"
-                value={adjustAmount}
-                onChange={(e) => setAdjustAmount(parseFloat(e.target.value))}
-                placeholder="0.00"
-              />
-            </div>
-            <DialogFooter>
-              <Button
-                variant="outline"
-                onClick={() => setShowAdjustModal(false)}
+          <div className="grid gap-2 mt-2">
+            <Label htmlFor="adjust-amount">$ Amount</Label>
+            <Input
+              id="adjust-amount"
+              type="number"
+              step="0.01"
+              inputMode="decimal"
+              value={adjustAmount}
+              onChange={(e) => {
+                setAdjustAmount(parseFloat(e.target.value));
+                setAdjustError("");
+              }}
+              placeholder="0.00"
+              aria-invalid={adjustError ? true : false}
+            />
+            {adjustError && (
+              <p className="text-destructive text-sm mt-1">{adjustError}</p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowAdjustModal(false)}
               >
                 Cancel
               </Button>
               <Button
                 onClick={async () => {
+                  if (adjustType === "withdraw" && adjustAmount > cash) {
+                    setAdjustError("Insufficient available cash");
+                    return;
+                  }
                   try {
                     await axios.post(
                       `/api/buckets/${id}`,

--- a/src/components/trades/AddTradeForm.jsx
+++ b/src/components/trades/AddTradeForm.jsx
@@ -28,7 +28,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import axios from "axios";
 
-const AddTradeForm = ({ bucketId, trade = null, onClose, onCreate }) => {
+const AddTradeForm = ({ bucketId, trade = null, cash = 0, onClose, onCreate }) => {
   // General fields
   const [market, setMarket] = useState(trade?.market || "");
   const [symbol, setSymbol] = useState(trade?.symbol || "");
@@ -45,6 +45,7 @@ const AddTradeForm = ({ bucketId, trade = null, onClose, onCreate }) => {
   const [notes, setNotes] = useState(trade?.notes || "");
   const [confidence, setConfidence] = useState(trade?.confidence || 0);
   const [errors, setErrors] = useState({ symbol: false, quantity: false, price: false });
+  const [cashError, setCashError] = useState("");
 
   useEffect(() => {
     if (trade) {
@@ -71,6 +72,13 @@ const AddTradeForm = ({ bucketId, trade = null, onClose, onCreate }) => {
       return;
     }
     setErrors({ symbol: false, quantity: false, price: false });
+
+    const totalCost = Number(price) * Number(quantity);
+    if (totalCost > cash) {
+      setCashError("Insufficient available cash");
+      return;
+    }
+    setCashError("");
 
     const payload = {
       symbol,
@@ -215,7 +223,10 @@ const AddTradeForm = ({ bucketId, trade = null, onClose, onCreate }) => {
                     id="quantity"
                     type="number"
                     value={quantity}
-                    onChange={(e) => setQuantity(e.target.value)}
+                    onChange={(e) => {
+                      setQuantity(e.target.value);
+                      setCashError("");
+                    }}
                     aria-invalid={errors.quantity}
                   />
                   {errors.quantity && (
@@ -231,11 +242,17 @@ const AddTradeForm = ({ bucketId, trade = null, onClose, onCreate }) => {
                     type="number"
                     step="0.01"
                     value={price}
-                    onChange={(e) => setPrice(e.target.value)}
+                    onChange={(e) => {
+                      setPrice(e.target.value);
+                      setCashError("");
+                    }}
                     aria-invalid={errors.price}
                   />
                   {errors.price && (
                     <p className="text-destructive text-sm mt-1">Price required</p>
+                  )}
+                  {cashError && (
+                    <p className="text-destructive text-sm mt-1">{cashError}</p>
                   )}
                 </div>
               </div>

--- a/src/components/trades/AddTradeForm.jsx
+++ b/src/components/trades/AddTradeForm.jsx
@@ -46,6 +46,7 @@ const AddTradeForm = ({ bucketId, trade = null, cash = 0, onClose, onCreate }) =
   const [confidence, setConfidence] = useState(trade?.confidence || 0);
   const [errors, setErrors] = useState({ symbol: false, quantity: false, price: false });
   const [cashError, setCashError] = useState("");
+  const [cashErrorField, setCashErrorField] = useState(null);
 
   useEffect(() => {
     if (trade) {
@@ -73,11 +74,19 @@ const AddTradeForm = ({ bucketId, trade = null, cash = 0, onClose, onCreate }) =
     }
     setErrors({ symbol: false, quantity: false, price: false });
 
-    const totalCost = Number(price) * Number(quantity);
+    const numPrice = Number(price);
+    const numQty = Number(quantity);
+    const totalCost = numPrice * numQty;
     if (totalCost > cash) {
+      if (numQty > cash / (numPrice || 1)) {
+        setCashErrorField("quantity");
+      } else {
+        setCashErrorField("price");
+      }
       setCashError("Insufficient available cash");
       return;
     }
+    setCashErrorField(null);
     setCashError("");
 
     const payload = {
@@ -226,11 +235,15 @@ const AddTradeForm = ({ bucketId, trade = null, cash = 0, onClose, onCreate }) =
                     onChange={(e) => {
                       setQuantity(e.target.value);
                       setCashError("");
+                      setCashErrorField(null);
                     }}
                     aria-invalid={errors.quantity}
                   />
                   {errors.quantity && (
                     <p className="text-destructive text-sm mt-1">Qty required</p>
+                  )}
+                  {cashError && cashErrorField === "quantity" && (
+                    <p className="text-destructive text-sm mt-1">{cashError}</p>
                   )}
                 </div>
                 <div>
@@ -245,13 +258,14 @@ const AddTradeForm = ({ bucketId, trade = null, cash = 0, onClose, onCreate }) =
                     onChange={(e) => {
                       setPrice(e.target.value);
                       setCashError("");
+                      setCashErrorField(null);
                     }}
                     aria-invalid={errors.price}
                   />
                   {errors.price && (
                     <p className="text-destructive text-sm mt-1">Price required</p>
                   )}
-                  {cashError && (
+                  {cashError && cashErrorField === "price" && (
                     <p className="text-destructive text-sm mt-1">{cashError}</p>
                   )}
                 </div>

--- a/src/lib/bucketUtils.js
+++ b/src/lib/bucketUtils.js
@@ -1,0 +1,23 @@
+export async function calculateAvailableCash(supabase, bucketId, userId) {
+  const { data: bucket } = await supabase
+    .from("buckets")
+    .select("bucket_size")
+    .eq("id", bucketId)
+    .eq("user_id", userId)
+    .single();
+  if (!bucket) return 0;
+
+  const { data: trades } = await supabase
+    .from("trades")
+    .select("quantity, price")
+    .eq("bucket_id", bucketId)
+    .eq("user_id", userId)
+    .neq("status", "CLOSED");
+
+  const openValue = (trades || []).reduce(
+    (sum, t) => sum + Number(t.quantity) * Number(t.price),
+    0
+  );
+
+  return Number(bucket.bucket_size) - openValue;
+}


### PR DESCRIPTION
## Summary
- prevent overspending when buying trades
- block withdrawals that exceed cash
- ignore invalid sell quantities
- expose helper to calculate available cash
- show error in withdraw modal before submitting

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686f46a4c0788326b8fe4ec303117d29