### PR TITLE
Add bucket delete confirmation with cascade

### DIFF
--- a/src/app/buckets/page.js
+++ b/src/app/buckets/page.js
@@ -7,6 +7,14 @@ import Link from "next/link";
 import BucketGrid from "@/components/buckets/BucketGrid";
 import CreateBucketModal from "@/components/buckets/CreateBucketModal";
 import BucketDetailModal from "@/components/buckets/BucketDetailModal";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
 // import { useStore } from "../../store";
 import { useBucketStore } from "@/store/useBucketStore";
 
@@ -19,6 +27,7 @@ export default function Buckets() {
 
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [selectedBucket, setSelectedBucket] = useState(null);
+  const [showDeletedDialog, setShowDeletedDialog] = useState(false);
 
   // const fetchBuckets = async () => {
   //   try {
@@ -33,6 +42,10 @@ export default function Buckets() {
 
   useEffect(() => {
     fetchBuckets();
+    if (typeof window !== "undefined" && localStorage.getItem("bucketDeleted")) {
+      setShowDeletedDialog(true);
+      localStorage.removeItem("bucketDeleted");
+    }
   }, [fetchBuckets]);
 
   const handleCreate = (name, bucketSize) => {
@@ -64,6 +77,19 @@ export default function Buckets() {
           bucket={selectedBucket}
           onClose={() => setSelectedBucket(null)}
         />
+      )}
+
+      {showDeletedDialog && (
+        <Dialog open onOpenChange={(open) => !open && setShowDeletedDialog(false)}>
+          <DialogContent className="max-w-sm">
+            <DialogHeader>
+              <DialogTitle>Bucket deleted</DialogTitle>
+            </DialogHeader>
+            <DialogFooter>
+              <Button onClick={() => setShowDeletedDialog(false)}>OK</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       )}
     </div>
   );

--- a/src/components/trades/AddTradeForm.jsx
+++ b/src/components/trades/AddTradeForm.jsx
@@ -28,7 +28,14 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import axios from "axios";
 
-const AddTradeForm = ({ bucketId, trade = null, cash = 0, onClose, onCreate }) => {
+const AddTradeForm = ({
+  bucketId,
+  trade = null,
+  cash = 0,
+  onClose,
+  onCreate,
+  onDeleted,
+}) => {
   // General fields
   const [market, setMarket] = useState(trade?.market || "");
   const [symbol, setSymbol] = useState(trade?.symbol || "");
@@ -119,6 +126,8 @@ const AddTradeForm = ({ bucketId, trade = null, cash = 0, onClose, onCreate }) =
     }
   };
 
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
   const handleDelete = async () => {
     if (!trade?.id) return;
     try {
@@ -126,6 +135,7 @@ const AddTradeForm = ({ bucketId, trade = null, cash = 0, onClose, onCreate }) =
         withCredentials: true,
       });
       onCreate?.();
+      onDeleted?.();
       onClose();
     } catch (err) {
       console.error(err);
@@ -319,7 +329,11 @@ const AddTradeForm = ({ bucketId, trade = null, cash = 0, onClose, onCreate }) =
 
             <div className="flex justify-between mt-4">
               {trade?.id && (
-                <Button type="button" variant="destructive" onClick={handleDelete}>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  onClick={() => setShowDeleteConfirm(true)}
+                >
                   Delete
                 </Button>
               )}
@@ -331,6 +345,25 @@ const AddTradeForm = ({ bucketId, trade = null, cash = 0, onClose, onCreate }) =
         </Tabs>
       </DialogContent>
     </Dialog>
+
+    {showDeleteConfirm && (
+      <Dialog open onOpenChange={(open) => !open && setShowDeleteConfirm(false)}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Delete Trade</DialogTitle>
+          </DialogHeader>
+          <p className="my-2">Are you sure you want to delete this trade?</p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowDeleteConfirm(false)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleDelete}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    )}
   );
 };
 


### PR DESCRIPTION
## Summary
- cascade delete trades and transactions from API
- prompt before deleting buckets and redirect to buckets list on success
- show "bucket deleted" confirmation dialog
- add confirmation dialogs when deleting trades from the table or edit dialog

## Testing
- `npm install`
- `npm run lint` *(shows lint warning about missing dependency)*

------
https://chatgpt.com/codex/tasks/task_e_686f5eb18c70832699263b434226605d