### PR TITLE
Allow null target or stoploss

### DIFF
--- a/src/app/api/buckets/[id]/trades/[tradeId]/route.js
+++ b/src/app/api/buckets/[id]/trades/[tradeId]/route.js
@@ -38,14 +38,18 @@ export async function PUT(request, { params }) {
     return_percent,
   } = await request.json();
 
+  const parsedTarget = target === "" || target === undefined ? null : Number(target);
+  const parsedStopLoss =
+    stop_loss === "" || stop_loss === undefined ? null : Number(stop_loss);
+
   const { data: trade, error } = await supabaseAdmin
     .from("trades")
     .update({
       symbol,
       notes,
       market,
-      target,
-      stop_loss,
+      target: parsedTarget,
+      stop_loss: parsedStopLoss,
       date,
       quantity,
       price,

--- a/src/app/api/buckets/[id]/trades/route.js
+++ b/src/app/api/buckets/[id]/trades/route.js
@@ -34,8 +34,20 @@ export async function GET(request, { params }) {
 export async function POST(request, { params }) {
   const { id: bucketId } = params;
   const user = await verifyUserFromCookie(request);
-  const { symbol, notes, market, target, stop_loss, date, quantity, price } =
-    await request.json();
+  const {
+    symbol,
+    notes,
+    market,
+    target,
+    stop_loss,
+    date,
+    quantity,
+    price,
+  } = await request.json();
+
+  const parsedTarget = target === "" || target === undefined ? null : Number(target);
+  const parsedStopLoss =
+    stop_loss === "" || stop_loss === undefined ? null : Number(stop_loss);
 
   const tradeCost = Number(price) * Number(quantity);
   const availableCash = await calculateAvailableCash(
@@ -59,8 +71,8 @@ export async function POST(request, { params }) {
         symbol,
         notes,
         market,
-        target,
-        stop_loss,
+        target: parsedTarget,
+        stop_loss: parsedStopLoss,
         quantity,
         price,
         status: "OPEN",


### PR DESCRIPTION
## Summary
- permit empty target and stoploss values when creating or editing a trade

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68748879c9e8832686b2332a0278db4a