### PR TITLE
Improve trade close calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ export async function POST(request) {
 
 Bucket endpoints combine authentication with Supabase queries to fetch bucket details, trades and transactions.
 
+### Tracking Trade Executions
+
+Each buy or sell action now records a row in `bucket_transactions` with a
+`trade_id` referencing the related trade. This linkage allows the API to
+calculate weighted exit prices and total returns when a position is fully
+closed.
+
 ### Forms and UI Components
 
 - `AddTradeForm.jsx` and `SellTradeForm.jsx` provide dialogs for creating or closing trades.

--- a/src/app/api/buckets/[id]/sell/route.js
+++ b/src/app/api/buckets/[id]/sell/route.js
@@ -26,16 +26,9 @@ export async function POST(request, { params }) {
     const sellQty = Number(qty);
     if (sellQty <= 0 || sellQty > Number(trade.quantity)) continue;
     const remaining = Number(trade.quantity) - sellQty;
-    const updates = { quantity: remaining };
-    if (remaining <= 0) {
-      updates.status = "CLOSED";
-      updates.exit_price = price;
-      updates.return_amount = (price - trade.price) * Number(trade.quantity);
-      updates.return_percent = ((price - trade.price) / trade.price) * 100;
-    }
     await supabaseAdmin
       .from("trades")
-      .update(updates)
+      .update({ quantity: remaining })
       .eq("id", trade_id)
       .eq("bucket_id", bucketId)
       .eq("user_id", user.id);
@@ -52,8 +45,47 @@ export async function POST(request, { params }) {
         description: `${trade.symbol} - SELL`,
         qty: sellQty,
         price,
+        trade_id: trade_id,
       },
     ]);
+
+    if (remaining <= 0) {
+      const { data: sells } = await supabaseAdmin
+        .from("bucket_transactions")
+        .select("qty, price")
+        .eq("bucket_id", bucketId)
+        .eq("user_id", user.id)
+        .eq("trade_id", trade_id)
+        .eq("description", `${trade.symbol} - SELL`);
+
+      const totalQty = (sells || []).reduce(
+        (sum, tx) => sum + Number(tx.qty),
+        0
+      );
+      const weightedExit = (sells || []).reduce(
+        (sum, tx) => sum + Number(tx.price) * Number(tx.qty),
+        0
+      );
+      const exitPrice = totalQty ? weightedExit / totalQty : price;
+      const returnAmount = (sells || []).reduce(
+        (sum, tx) => sum + (Number(tx.price) - trade.price) * Number(tx.qty),
+        0
+      );
+      const returnPercent =
+        totalQty > 0 ? (returnAmount / (trade.price * totalQty)) * 100 : 0;
+
+      await supabaseAdmin
+        .from("trades")
+        .update({
+          status: "CLOSED",
+          exit_price: exitPrice,
+          return_amount: returnAmount,
+          return_percent: returnPercent,
+        })
+        .eq("id", trade_id)
+        .eq("bucket_id", bucketId)
+        .eq("user_id", user.id);
+    }
   }
 
   if (totalProfit !== 0) {

--- a/src/app/api/buckets/[id]/trades/route.js
+++ b/src/app/api/buckets/[id]/trades/route.js
@@ -94,6 +94,7 @@ export async function POST(request, { params }) {
       description: `${symbol} - BUY`,
       qty: quantity,
       price,
+      trade_id: trade.id,
     },
   ]);
 

--- a/src/app/buckets/[id]/page.js
+++ b/src/app/buckets/[id]/page.js
@@ -82,8 +82,7 @@ export default function BucketDetailsPage() {
         if (t.status === "CLOSED") {
           const sellTxs = txs.filter(
             (tx) =>
-              tx.description === `${t.symbol} - SELL` &&
-              new Date(tx.created_at) >= new Date(t.created_at)
+              tx.trade_id === t.id && tx.description === `${t.symbol} - SELL`
           );
           if (sellTxs.length > 0) {
             const last = sellTxs[sellTxs.length - 1];


### PR DESCRIPTION
## Summary
- link bucket transactions to trades via `trade_id`
- compute weighted exit price and return when closing trades
- show hold duration using the new `trade_id` relationship
- document new `trade_id` column for executions

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6877438b765c8326b13eed24a8504964